### PR TITLE
Add editing and deletion to journal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -633,6 +633,24 @@ body {
   font-size: 0.875rem;
 }
 
+.entry-name {
+  margin-left: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+}
+
+.icon-button {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0 0.25rem;
+}
+
+.icon-button:hover {
+  color: var(--color-primary);
+}
+
 .entry-content {
   color: var(--color-text-secondary);
   line-height: 1.7;

--- a/src/App.js
+++ b/src/App.js
@@ -53,22 +53,40 @@ function App() {
     setMoodData(prev => [...prev, newEntry]);
   };
 
-  const addJournalEntry = (title, content) => {
-    const newEntry = {
-      id: Date.now(),
-      date: new Date().toISOString(),
-      title,
-      content
-    };
-    setJournalEntries(prev => [...prev, newEntry]);
+const addJournalEntry = (title, content, name) => {
+  const newEntry = {
+    id: Date.now(),
+    date: new Date().toISOString(),
+    title,
+    content,
+    name
   };
+  setJournalEntries(prev => [...prev, newEntry]);
+};
+
+const updateJournalEntry = (id, updatedFields) => {
+  setJournalEntries(prev =>
+    prev.map(entry => (entry.id === id ? { ...entry, ...updatedFields } : entry))
+  );
+};
+
+const deleteJournalEntry = id => {
+  setJournalEntries(prev => prev.filter(entry => entry.id !== id));
+};
 
   const renderContent = () => {
     switch (activeTab) {
       case 'mood':
         return <MoodLogger onAddMood={addMoodEntry} />;
       case 'journal':
-        return <Journal entries={journalEntries} onAddEntry={addJournalEntry} />;
+        return (
+          <Journal
+            entries={journalEntries}
+            onAddEntry={addJournalEntry}
+            onUpdateEntry={updateJournalEntry}
+            onDeleteEntry={deleteJournalEntry}
+          />
+        );
       case 'analytics':
         return <Analytics moodData={moodData} />;
       default:

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders MindFlow header', () => {
+test('renders app header', () => {
   render(<App />);
-  const header = screen.getByText(/MindFlow/i);
-  expect(header).toBeInTheDocument();
+  const headerElement = screen.getByText(/MindFlow/i);
+  expect(headerElement).toBeInTheDocument();
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders MindFlow header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = screen.getByText(/MindFlow/i);
+  expect(header).toBeInTheDocument();
 });

--- a/src/components/Journal.js
+++ b/src/components/Journal.js
@@ -2,18 +2,26 @@ import React, { useState } from 'react';
 import { PlusCircle, BookOpen, Calendar, Edit3, Trash2 } from 'lucide-react';
 import { format } from 'date-fns';
 
-const Journal = ({ entries, onAddEntry }) => {
+const Journal = ({ entries, onAddEntry, onUpdateEntry, onDeleteEntry }) => {
   const [isWriting, setIsWriting] = useState(false);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [name, setName] = useState('');
   const [expandedEntry, setExpandedEntry] = useState(null);
+  const [editingId, setEditingId] = useState(null);
 
   const handleSubmit = (e) => {
     e.preventDefault();
     if (title.trim() && content.trim()) {
-      onAddEntry(title, content);
+      if (editingId) {
+        onUpdateEntry(editingId, { title, content, name });
+      } else {
+        onAddEntry(title, content, name);
+      }
       setTitle('');
       setContent('');
+      setName('');
+      setEditingId(null);
       setIsWriting(false);
     }
   };
@@ -57,6 +65,18 @@ const Journal = ({ entries, onAddEntry }) => {
           <div className="journal-editor">
             <form onSubmit={handleSubmit} className="entry-form">
               <div className="form-group">
+                <label htmlFor="name" className="form-label">Your Name</label>
+                <input
+                  id="name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Who is writing this?"
+                  className="title-input"
+                />
+              </div>
+
+              <div className="form-group">
                 <label htmlFor="title" className="form-label">
                   Entry Title
                 </label>
@@ -92,6 +112,8 @@ const Journal = ({ entries, onAddEntry }) => {
                     setIsWriting(false);
                     setTitle('');
                     setContent('');
+                    setName('');
+                    setEditingId(null);
                   }}
                   className="cancel-button"
                 >
@@ -125,9 +147,34 @@ const Journal = ({ entries, onAddEntry }) => {
                   <div key={entry.id} className="journal-entry">
                     <div className="entry-header" onClick={() => toggleEntry(entry.id)}>
                       <h3 className="entry-title">{entry.title}</h3>
+                      <span className="entry-name">{entry.name}</span>
                       <div className="entry-meta">
                         <Calendar size={14} />
                         <span>{formatDate(entry.date)}</span>
+                        <button
+                          type="button"
+                          className="icon-button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setIsWriting(true);
+                            setEditingId(entry.id);
+                            setTitle(entry.title);
+                            setContent(entry.content);
+                            setName(entry.name || '');
+                          }}
+                        >
+                          <Edit3 size={14} />
+                        </button>
+                        <button
+                          type="button"
+                          className="icon-button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onDeleteEntry(entry.id);
+                          }}
+                        >
+                          <Trash2 size={14} />
+                        </button>
                       </div>
                     </div>
                     


### PR DESCRIPTION
## Summary
- add update & delete handlers in `App`
- allow editing & deleting journal entries with new buttons
- add name field when creating or editing an entry
- style journal entry name and icon buttons
- fix failing test

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68411cbcd780832a87f6a48b70db7e56