### PR TITLE
Remove minion gif asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🧠 MindFlow - Mood Tracking App
+# Minion's Daily Report - Mood Tracking App
 
 https://mood-tracking-e309krrmj-yeshs-projects-be811dd8.vercel.app/
 

--- a/src/App.css
+++ b/src/App.css
@@ -114,6 +114,8 @@ body {
   flex-shrink: 0;
 }
 
+
+
 .logo-emoji {
   font-size: 2rem;
   margin-right: 0.75rem;
@@ -215,6 +217,7 @@ body {
 
 /* Mood Logger Styles */
 .mood-logger {
+  position: relative;
   display: flex;
   justify-content: center;
   align-items: flex-start;

--- a/src/App.js
+++ b/src/App.js
@@ -99,8 +99,8 @@ const deleteJournalEntry = id => {
       <header className="app-header">
         <div className="header-content">
           <div className="logo">
-            <div className="logo-emoji">🧠</div>
-            <h1>MindFlow</h1>
+            <span role="img" aria-label="banana" className="logo-emoji">🍌</span>
+            <h1>Minion's Daily Report</h1>
           </div>
           
           <nav className="nav-tabs">

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -3,6 +3,6 @@ import App from './App';
 
 test('renders app header', () => {
   render(<App />);
-  const headerElement = screen.getByText(/MindFlow/i);
+  const headerElement = screen.getByText(/Minion's Daily Report/i);
   expect(headerElement).toBeInTheDocument();
 });

--- a/src/components/IdleMinions.css
+++ b/src/components/IdleMinions.css
@@ -1,0 +1,41 @@
+.idle-minions {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.idle-minion {
+  position: absolute;
+  bottom: -80px;
+  width: 60px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  animation: bounce 6s infinite ease-in-out;
+}
+
+@keyframes bounce {
+  0% {
+    transform: translateY(0) scale(1);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  50% {
+    transform: translateY(-60vh) scale(1.2);
+  }
+  80% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: 0;
+  }
+}

--- a/src/components/IdleMinions.js
+++ b/src/components/IdleMinions.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import './IdleMinions.css';
+
+const IdleMinions = () => {
+  const minions = Array.from({ length: 5 });
+  return (
+    <div className="idle-minions">
+      {minions.map((_, index) => (
+        <div
+          key={index}
+          className="idle-minion"
+          style={{ animationDelay: `${index * 1.2}s`, left: `${10 + index * 15}%` }}
+        >
+          😃
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default IdleMinions;

--- a/src/components/MoodLogger.js
+++ b/src/components/MoodLogger.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Smile, Frown, Meh, Angry, Heart, Star, CheckCircle, Wind } from 'lucide-react';
 import BreathingMeditation from './BreathingMeditation';
+import IdleMinions from './IdleMinions';
 
 const MoodLogger = ({ onAddMood }) => {
   const [selectedMood, setSelectedMood] = useState(null);
@@ -109,10 +110,11 @@ const MoodLogger = ({ onAddMood }) => {
         )}
       </div>
 
-      <BreathingMeditation 
-        isOpen={showBreathing} 
-        onClose={() => setShowBreathing(false)} 
+      <BreathingMeditation
+        isOpen={showBreathing}
+        onClose={() => setShowBreathing(false)}
       />
+      <IdleMinions />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove local `minion.gif` asset and use an emoji for the logo
- drop image reference in README
- adjust idle animation component to show emoji instead of the gif

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684121361f3c832a97427d8480461160